### PR TITLE
Invalidate parent product cache on child stock item save

### DIFF
--- a/app/code/local/MSP/LTS2/Model/Cache.php
+++ b/app/code/local/MSP/LTS2/Model/Cache.php
@@ -382,7 +382,15 @@ class MSP_LTS2_Model_Cache
     {
         $invalidations = Mage::getSingleton('msp_ltsr2/cache')->getBlocksModelInvalidation($modelInstance);
         $tags = array();
-        
+
+        if ($modelInstance instanceof Mage_CatalogInventory_Model_Stock_Item) {
+            $parentIds = Mage::getSingleton('catalog/product_type_configurable')
+                ->getParentIdsByChild($modelInstance->getProductId());
+            foreach($parentIds as $parentId) {
+                $tags[] = 'CATALOG_PRODUCT_' . $parentId;
+            }
+        }
+
         foreach ($invalidations['global'] as $blockName) {
             $tags[] = 'MSP_BLOCK_NAME_'.$blockName;
         }

--- a/app/code/local/MSP/LTS2/etc/config.xml
+++ b/app/code/local/MSP/LTS2/etc/config.xml
@@ -19,7 +19,7 @@
 <config>
 	<modules>
 		<MSP_LTS2>
-			<version>1.0.1</version>
+			<version>1.0.2</version>
 		</MSP_LTS2>
 	</modules>
 	


### PR DESCRIPTION
When child stock data change (eg from in stock to out of stock) parent product page does not reflect this change because it is cached. Whit this pull request, cache will be invalidated for parent products of children with stock data changes.